### PR TITLE
Add license checks CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,28 @@ jobs:
       - name: Run tests
         run: bundle exec rspec
 
+  license_checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+      - name: Check licenses
+        run: bundle exec license_finder
+
   summary:
     name: CI Summary
     runs-on: ubuntu-latest
     needs:
       - test
+      - license_checks
     if: always()
 
     steps:
       - name: Successful builds?
         run: |
           if ${{ needs.test.result != 'success' }}; then exit 1; fi
+          if ${{ needs.license_checks.result != 'success' }}; then exit 1; fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,8 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.3"
-          bundler-cache: true
+      - name: Install gems
+        run: bundle install
       - name: Check licenses
         run: bundle exec license_finder
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 pkg
 Gemfile.lock
 .byebug_history
+/doc/*
+!/doc/dependency_decisions.yml

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gemspec
 
 group :test, :development do
+  gem 'license_finder', require: false
   gem 'rubocop'
   gem 'rubocop-performance'
   gem 'rubocop-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,9 +12,18 @@ GEM
     ast (2.4.3)
     bigdecimal (4.1.2)
     byebug (11.1.3)
+    csv (3.3.5)
     diff-lcs (1.5.1)
     json (2.19.4)
     language_server-protocol (3.17.0.5)
+    license_finder (7.2.1)
+      bundler
+      csv (~> 3.2)
+      rubyzip (>= 1, < 3)
+      thor (~> 1.2)
+      tomlrb (>= 1.3, < 2.1)
+      with_env (= 1.1.0)
+      xml-simple (~> 1.1.9)
     lint_roller (1.1.0)
     mini_portile2 (2.8.5)
     nkf (0.2.0)
@@ -30,6 +39,7 @@ GEM
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.12.0)
+    rexml (3.4.4)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -65,15 +75,22 @@ GEM
       lint_roller (~> 1.1)
       rubocop (~> 1.81)
     ruby-progressbar (1.13.0)
+    rubyzip (2.4.1)
+    thor (1.5.0)
+    tomlrb (2.0.3)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
+    with_env (1.1.0)
+    xml-simple (1.1.9)
+      rexml
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   byebug (~> 11.1.3)
+  license_finder
   ofx!
   rake (~> 13.2.1)
   rspec (~> 3.10)

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -4,34 +4,16 @@
   - :who:
     :why:
     :versions: []
-    :when: 2026-04-28 11:46:56.925393000 Z
+    :when: 2026-04-28 13:02:26.508014000 Z
 - - :permit
   - Simplified BSD
   - :who:
     :why:
     :versions: []
-    :when: 2026-04-28 11:46:57.523411000 Z
+    :when: 2026-04-28 13:02:27.087052000 Z
 - - :permit
   - ruby
   - :who:
     :why:
     :versions: []
-    :when: 2026-04-28 11:46:58.026018000 Z
-- - :permit
-  - Artistic-2.0
-  - :who:
-    :why:
-    :versions: []
-    :when: 2026-04-28 11:46:58.536318000 Z
-- - :permit
-  - GPL-2.0-or-later
-  - :who:
-    :why:
-    :versions: []
-    :when: 2026-04-28 11:46:59.254571000 Z
-- - :permit
-  - Apache 2.0
-  - :who:
-    :why:
-    :versions: []
-    :when: 2026-04-28 11:46:59.757290000 Z
+    :when: 2026-04-28 13:02:27.532935000 Z

--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -1,0 +1,37 @@
+---
+- - :permit
+  - MIT
+  - :who:
+    :why:
+    :versions: []
+    :when: 2026-04-28 11:46:56.925393000 Z
+- - :permit
+  - Simplified BSD
+  - :who:
+    :why:
+    :versions: []
+    :when: 2026-04-28 11:46:57.523411000 Z
+- - :permit
+  - ruby
+  - :who:
+    :why:
+    :versions: []
+    :when: 2026-04-28 11:46:58.026018000 Z
+- - :permit
+  - Artistic-2.0
+  - :who:
+    :why:
+    :versions: []
+    :when: 2026-04-28 11:46:58.536318000 Z
+- - :permit
+  - GPL-2.0-or-later
+  - :who:
+    :why:
+    :versions: []
+    :when: 2026-04-28 11:46:59.254571000 Z
+- - :permit
+  - Apache 2.0
+  - :who:
+    :why:
+    :versions: []
+    :when: 2026-04-28 11:46:59.757290000 Z


### PR DESCRIPTION
## Why do we need this?

Adds license compliance checking to the CI pipeline, pending Legal approval of the permitted licenses.

- `license_checks` CI job — runs `license_finder` on every push/PR
- `doc/dependency_decisions.yml` — approved license types: MIT, Simplified BSD, ruby
- CI Summary updated to require both `test` and `license_checks` to pass
- `license_finder` added to dev dependencies

Notion:
https://www.notion.so/scribetech/ofx-442326442d614106b53c13eaa0610faf
https://www.notion.so/scribetech/Repositories-hardening-1cfc3cfcebe842bc88c3ac4fae4a0506

<img width="1272" height="1204" alt="image (2)" src="https://github.com/user-attachments/assets/e26b2786-73ab-4587-8982-dcb3cc7b4d03" />

